### PR TITLE
feat(rsip): Civ6 style RSIP view + minimal types fix

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,3 +80,89 @@ export interface AppState {
   viewingChainId: string | null;
   completionHistory: CompletionHistory[];
 }
+
+// Minimal RSIP types (added to satisfy components importing RSIPNode/RSIPTreeNode/RSIPMeta)
+export type RSIPNode = {
+  id: string;
+  parentId?: string;
+  title: string;
+  rule: string;
+  sortOrder: number;
+  createdAt: Date;
+  useTimer?: boolean;
+  timerMinutes?: number;
+  // allow small, opt-in metadata used by RSIPView (type/emoji)
+  type?: string;
+  emoji?: string;
+};
+
+export interface RSIPTreeNode extends RSIPNode {
+  children: RSIPTreeNode[];
+  depth: number;
+}
+
+export interface RSIPMeta {
+  allowMultiplePerDay?: boolean;
+  lastAddedAt?: Date | string;
+  // persisted custom type presets
+  typePresets?: Array<{ type: string; emoji: string }>;
+}
+
+// Exception rule types used across services (enum-like)
+export enum ExceptionRuleType {
+  PAUSE_ONLY = 'PAUSE_ONLY',
+  EARLY_COMPLETION_ONLY = 'EARLY_COMPLETION_ONLY',
+}
+
+export interface ExceptionRule {
+  id: string;
+  type: ExceptionRuleType | string;
+  name: string;
+  isActive?: boolean;
+  usageCount?: number;
+  lastUsedAt?: Date | null;
+  createdAt?: Date;
+  message?: string;
+}
+
+// Error codes used by exception services
+export enum ExceptionRuleError {
+  RULE_NOT_FOUND = 'RULE_NOT_FOUND',
+  INVALID_RULE_TYPE = 'INVALID_RULE_TYPE',
+  RULE_TYPE_MISMATCH = 'RULE_TYPE_MISMATCH',
+  VALIDATION_ERROR = 'VALIDATION_ERROR',
+}
+
+// Lightweight enhanced exception with chainable helpers used in services/tests
+export class EnhancedExceptionRuleException extends Error {
+  public code?: ExceptionRuleError;
+  public detail?: string;
+  public meta?: any;
+  public suggestions: string[] = [];
+
+  constructor(message?: string) {
+    super(message);
+    this.name = 'EnhancedExceptionRuleException';
+  }
+
+  static createUserFriendly(code: ExceptionRuleError, userMessage?: string, detail?: string, meta?: any) {
+    const e = new EnhancedExceptionRuleException(userMessage || String(code));
+    e.code = code;
+    e.detail = detail;
+    e.meta = meta;
+    return e;
+  }
+
+  addSuggestedAction(action: string) {
+    this.suggestions.push(action);
+    return this;
+  }
+}
+
+// Backwards-compatible lightweight exception class for places that import ExceptionRuleException
+export class ExceptionRuleException extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'ExceptionRuleException';
+  }
+}


### PR DESCRIPTION
实现：\n- Civ6 风格横向卡片视图（SVG 贝塞尔连线、箭头、enter/exit 动画、链路高亮、拖拽重置父节点）\n- 支持节点类型与 Emoji，可在 meta 中持久化预设\n\n修复：\n- 最小化地在 src/types/index.ts 添加 RSIP 类型与异常相关导出，解决 dev 构建时的缺失导出错误（仅做兼容性补足，尽量不改动其它实现）\n\n说明：请在 review 时关注 types 的命名与导出是否符合主分支预期。