### PR TITLE
fix: Correctly initialize parentId in ChainEditor

### DIFF
--- a/src/components/ChainEditor.tsx
+++ b/src/components/ChainEditor.tsx
@@ -44,7 +44,9 @@ export const ChainEditor: React.FC<ChainEditorProps> = ({
 }) => {
   const [name, setName] = useState(chain?.name || '');
   const [type, setType] = useState<ChainType>(chain?.type || 'unit');
-  const [parentId, setParentId] = useState(chain?.parentId || initialParentId || undefined);
+  // Fix: Only use initialParentId when creating a new chain (chain is undefined)
+  // When editing an existing chain, respect its parentId (even if undefined)
+  const [parentId, setParentId] = useState(chain ? chain.parentId : initialParentId);
   const [sortOrder] = useState(chain?.sortOrder || Math.floor(Date.now() / 1000));
   
   // Fix: Check if trigger is custom on init


### PR DESCRIPTION
## Bug Fix
- **Issue**: Standalone chains were incorrectly inheriting `initialParentId` when edited, causing the editor to display 'Task Group Belonging' UI and logic even for chains not in a group.
- **Fix**: Updated `ChainEditor` initialization to strictly respect the chain's existing `parentId` (even if undefined) when editing, and only use `initialParentId` for new chains.